### PR TITLE
Support object ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,5 +96,9 @@ The `gray-matter` package used in this module does not support TOML front matter
 hugo-algolia -toml
 ```
 
+#### A note about duplicated index entries and objectIDs
+
+Algolia assigns each entry in the index an objectID. It uses this attribute as primary key for an entry. If you want to update an entry, you must send the objectID for the entry you want to update. To prevent duplicated content, this package uses the page's URI as objectID. This way, you can generate the index as many times as you want and Algolia will only index content that has changed. If you want to override an objectID for an entry, you can especify it in the frontmatter.
+
 # License
 This project is based on the lunr plugin from https://github.com/dgrigg/hugo-lunr, but adapted for use with the Algolia search engine. It is under the ISC License. 

--- a/lib/index.js
+++ b/lib/index.js
@@ -262,6 +262,11 @@ function HugoAlgolia(options) {
         if (self.partial) {
           item = _.pick(item, self.customInd);
         }
+        
+        // Include an objectID to prevent duplicated entries in the index.
+        item.objectID = meta.data.objectID
+          ? meta.data.objectID
+          : item.uri
       }
     }
 


### PR DESCRIPTION
I just started using this package for a small project and it works great, thanks!

I bumped into a small issue. Since the package doesn't generate an objectID, you can end up creating duplicated entries in the index for the same content.

I made a change to use the URI as objectID and allow people to provide their own in the metadata. I also included a small note in the readme about this behavior.

I'd really appreciate it if you can take this change and publish a new version of the package. Let me know if you think I should make any changes.

🙏