### PR TITLE
Ignore drafts.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -278,8 +278,9 @@ function HugoAlgolia(options) {
       }
     });
 
-    // If item.index is false, we don't want to index this
-    if (meta.data.index === false) return;
+    // We don't want to index this if the index is false or
+    // this document is a draft.
+    if (meta.data.index === false || meta.data.draft === true) return;
 
     meta.content = removeMarkDown(meta.content);
     meta.content = stripTags(meta.content);


### PR DESCRIPTION
Don't index content that's in a draft.
Otherwise Algolia might reveal content that has not been
published yet.

Signed-off-by: David Calavera <david.calavera@gmail.com>