### PR TITLE
Fix TOML configuration parsing with correct matter parameters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -83,7 +83,13 @@ function HugoAlgolia(options) {
   }
 
   HugoAlgolia.prototype.setCredentials = function() {
-    const configMeta = matter.read(self.pathToCredentials);
+    const configMeta = matter.read(self.pathToCredentials, {
+      language: self.language,
+      delims: self.delims,
+      engines: {
+        toml: toml.parse.bind(toml)
+      }
+    });
     const creds = configMeta.data.algolia;
 
     if (creds) {


### PR DESCRIPTION
Hi,

Currently, **the configuration parsing fails when the configuration file is written in TOML**.

The `matter.read` call ([lib/index.js line 86](https://github.com/10Dimensional/hugo-algolia/blob/e1bd72a64ef095c607bee48cfe1b5ab37761094d/lib/index.js#L86)) correctly **reads** the config file and populates the `content` field but never gets to **parse** it and populate the `data` field. The end result is that the `algolia` section never actually gets parsed and the Algolia sending fails since it can't find the `appID` that should have been parsed from configuration.

The TOML is however correctly parsed when reading the front-matter later on, [lines 278-284](https://github.com/10Dimensional/hugo-algolia/blob/e1bd72a64ef095c607bee48cfe1b5ab37761094d/lib/index.js#L278).

The difference is that the `matter.read` in the case of config parsing **doesn't have any TOML engine passed to it**. This Pull Request fixes it!

I'm currently using hugo-algolia fixed with this and it works fine :slightly_smiling_face: 