### PR TITLE
Use config.toml as default config file if --toml is passed (Closes #7)

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -11,7 +11,7 @@ indexer
   .option("-s, --send", "Send to Algolia", false)
   .option("-m, --multiple-indices [value]", "Multiple categories")
   .option("-p, --custom-index", "Custom index")
-  .option("--config [value]", "Config file", "./config.yaml")
+  .option("--config [value]", "Config file")
   .option(
     "-c, --content-size [value]",
     "Content size to send to Algolia",

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,15 @@ function HugoAlgolia(options) {
   this.list = [];
   this.indices = {};
 
+  // Default configuration file
+  if (typeof options.config === 'undefined') {
+    if (options.toml) {
+      options.config = "./config.toml"
+    } else {
+      options.config = "./config.yaml"
+    }
+  }
+
   // Default creds
   this.algoliaCredentials = {
     indexName: "",


### PR DESCRIPTION
After seeing #7 and being concerned by it too (not that much of a big deal to pass `--config config.toml` though), I took the opportunity to improve default config format depending on the `--toml` option. However, this forces to stop using the `commander` default.

In the absence of a `--config` option, it will default to `./config.yaml` as it used to do. If `--toml` is passed however, it will default to `./config.toml`. In any case, it is still overrideable by the `--config [value]` parameter.

The implementation could probably be a better one, feel free to reject it if it's not good enough :wink: 