### PR TITLE
Add --config-toml

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -7,6 +7,7 @@ indexer
   .option("-i, --input [value]", "Input files", "content/**")
   .option("-o, --output [value]", "Output files", "public/algolia.json")
   .option("-t, --toml", "Parse with TOML", false)
+  .option("--config-toml", "Parse config with TOML", false)
   .option("-A, --all", `Turn off "other" category`, false)
   .option("-s, --send", "Send to Algolia", false)
   .option("-m, --multiple-indices [value]", "Multiple categories")

--- a/lib/index.js
+++ b/lib/index.js
@@ -83,7 +83,14 @@ function HugoAlgolia(options) {
   }
 
   HugoAlgolia.prototype.setCredentials = function() {
-    const configMeta = matter.read(self.pathToCredentials);
+    const configMeta = matter.read(self.pathToCredentials,{
+      language: options.configToml ? "toml" : null,
+      delims: options.configToml ? "+++" : null,
+      engines: {
+        toml: toml.parse.bind(toml)
+      }
+    });
+    
     const creds = configMeta.data.algolia;
 
     if (creds) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -83,15 +83,15 @@ function HugoAlgolia(options) {
   }
 
   HugoAlgolia.prototype.setCredentials = function() {
-    const configMeta = matter.read(self.pathToCredentials,{
-      language: options.configToml ? "toml" : null,
-      delims: options.configToml ? "+++" : null,
-      engines: {
-        toml: toml.parse.bind(toml)
-      }
-    });
-    
-    const creds = configMeta.data.algolia;
+    let config = {}
+    if (options.configToml) {
+      config = toml.parse(fs.readFileSync(self.pathToCredentials, 'utf-8'));
+    } else {
+      const configMeta = matter.read(self.pathToCredentials);
+      config = configMeta.data
+    }
+
+    const creds = config.algolia;
 
     if (creds) {
       self.algoliaCredentials = {


### PR DESCRIPTION
This adds the `--config-toml` flag that will parse the config file using TOML if specified.

Currently may not be the best option to do this, suggestions to improve more than welcome!