### PR TITLE
Fix url jump error, add Chinese support. 修复url跳转,支持中文

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -249,11 +249,19 @@ function HugoAlgolia(options) {
           compUriArray.pop();
           item.uri = compUriArray.join("/");
         }
+        // 修复url跳转错误，空格替换为'-', ASCII符号除了 / - _ 全部删除，汉字（CJK）标点符号\u3000-\u303F删除,/ /g全部替换而不是只替换第一处，转小写
+        item.uri = item.uri
+            .replace(' ', '-')
+            .replace(/[\u0021-\u002c\u002e\u003a-\u0040\u005b-\u005e\u0060\u007b-\u007e\u3000-\u303F]/g, '')
+            .toLowerCase()
+        // 修复在一篇文章中跳转另一篇文章时出错
+        item.uri = '/' + item.uri
 
         let content = stopword
           .removeStopwords(meta.content.split(/\s+/))
           .join(" ")
-          .replace(/\W/g, " ")
+          // content支持中文
+          .replace(/[^\w\u4E00-\u9FA5]/g, " ")
           .trim();
         let truncatedContent = truncate(content, _this.contentSize); // 20kB limit
         item.content = truncatedContent;
@@ -262,7 +270,7 @@ function HugoAlgolia(options) {
         if (self.partial) {
           item = _.pick(item, self.customInd);
         }
-        
+
         // Include an objectID to prevent duplicated entries in the index.
         item.objectID = meta.data.objectID
           ? meta.data.objectID


### PR DESCRIPTION
Adaptation: Hugo's url will handle spaces and symbols.
The content of the article supports Chinese.
url处理空格和标点符号，修复在文章中跳转另一个文章时url拼接错误
文章content支持中文（基本汉字）

### URL Jump Bug
For example I created a post with the command `hugo new "posts/Hello World.md"`

My browser's current url is `https://blog.example.com/`. When I search for "hello world", there is an article called "Hello World" in the search results. When I click on it, it jumps to `https://blog.example.com/posts/Hello%20World`, the result is 404. Because the actual address of this post is `https://blog.example.com/posts/hello-world`.

Another bug is that when my current url is `https://blog.example.com/posts/hello-world`. When I search and jump to another post called "test", my url becomes `https://blog.example.com/posts/hello-world/posts/test` instead of `https://blog.example.com/posts/test`.