### PR TITLE
Ignore files over 1 MB when indexing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -213,7 +213,7 @@ function HugoAlgolia(options) {
       let stats = fs.lstatSync(files[i]);
 
       // Remove folders, and ignore files over 1 MB
-      if (!stats.isDirectory()) && stats.size < 1000000) {
+      if (!stats.isDirectory() && stats.size < 1000000) {
         // If this is not a directory/folder, read the file
         self.readFile(files[i]);
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -212,8 +212,8 @@ function HugoAlgolia(options) {
     for (let i = 0; i < files.length; i++) {
       let stats = fs.lstatSync(files[i]);
 
-      // Remove folders, only gather actual files
-      if (!stats.isDirectory()) {
+      // Remove folders, and ignore files over 1 MB
+      if (!stats.isDirectory()) && stats.size < 1000000) {
         // If this is not a directory/folder, read the file
         self.readFile(files[i]);
       }


### PR DESCRIPTION
This makes hugo-algolia skip files over 1 MB.  This fixes #29.